### PR TITLE
Run docker using camera calibration directory on local disk.

### DIFF
--- a/docker/run_image.bash
+++ b/docker/run_image.bash
@@ -1,6 +1,6 @@
 IMAGE=anthonysimeonov/airobot-cuda-dev:latest
 XAUTH=/tmp/.docker.xauth
-CAMERA_CALIB_DIR=$PWD/../../camera_calibration
+CAMERA_CALIB_DIR=/root/catkin_ws/src/camera_calibration
 if [ ! -f $XAUTH ]
 then
     xauth_list=$(xauth nlist :0 | sed -e 's/^..../ffff/')

--- a/docker/run_image.bash
+++ b/docker/run_image.bash
@@ -1,5 +1,6 @@
 IMAGE=anthonysimeonov/airobot-cuda-dev:latest
 XAUTH=/tmp/.docker.xauth
+CAMERA_CALIB_DIR=$PWD/../../camera_calibration
 if [ ! -f $XAUTH ]
 then
     xauth_list=$(xauth nlist :0 | sed -e 's/^..../ffff/')
@@ -18,6 +19,7 @@ docker run -it \
     --volume="/tmp/.X11-unix:/tmp/.X11-unix:rw" \
     --env="XAUTHORITY=$XAUTH" \
     --volume="$XAUTH:$XAUTH" \
+    --volume="$CAMERA_CALIB_DIR/:/home/improbable/camera_calibration" \
     --volume="$PWD/../:/home/improbable/airobot/" \
     --privileged \
     --runtime=nvidia \


### PR DESCRIPTION
- Assume camera calibration is in the same directory as the airobot root directory.
- Allows persistence of camera calibration results.