### PR TITLE
add full ip

### DIFF
--- a/src/airobot/cfgs/assets/robotiq2f140.py
+++ b/src/airobot/cfgs/assets/robotiq2f140.py
@@ -21,6 +21,8 @@ _C.GAZEBO_COMMAND_TOPIC = '/gripper/gripper_cmd/goal'
 _C.JOINT_STATE_TOPIC = '/joint_states'
 # Prefix of IP address of machine on local network
 _C.IP_PREFIX = '192.168'
+
+_C.FULL_IP = '128.30.16.198'
 # time in seconds to wait for new gripper state before exiting
 _C.UPDATE_TIMEOUT = 5.0
 

--- a/src/airobot/ee_tool/robotiq2f140_real.py
+++ b/src/airobot/ee_tool/robotiq2f140_real.py
@@ -53,6 +53,7 @@ class Robotiq2F140Real(EndEffectorTool):
             self._err_thresh = 1
 
             self._local_ip_addr = None
+
             local_ip = self._get_local_ip()
             # we assume the machine is connected to a router
             if local_ip is not None:
@@ -293,7 +294,8 @@ class Robotiq2F140Real(EndEffectorTool):
         for ip in ip_list:
             if ip.startswith(self.cfgs.EETOOL.IP_PREFIX):
                 return ip
-        return None
+        return self.cfgs.EETOOL.FULL_IP
+        # return None
 
     def _initialize_comm(self):
         """


### PR DESCRIPTION
If someone uses an Ethernet switch, there is no 192 prefix IP created. In that case, they should specify the full IP in the config file.