### PR TITLE
Update setup.py: Change Python version specifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     package_data={
         'airobot': extra_pkg_files,
     },
-    python_requires='>=2.7.*, <3.11',
+    python_requires='>=2.7, <3.11',
     classifiers=[
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.7",


### PR DESCRIPTION
See issue #35. Apparently, the Python version specifier notation `.*` cannot be used together with `>=`.